### PR TITLE
Switch package namespace to dev.obrienlabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # doppler-radar-llm-codex
-doppler radar images model using codex - not the same as my manually created project at https://github.com/ObrienlabsDev/doppler-radar-ml
+
+Starter project for converting downloaded Doppler radar images into embeddings that can be
+fed into a generative model pipeline. This version uses Java 21 and the DJL (Deep Java
+Library) model zoo.
+
+## Prerequisites
+
+- Java 21
+- Maven 3.9+
+
+## Build
+
+```bash
+mvn -q -DskipTests package
+```
+
+## Embed radar imagery
+
+```bash
+mvn -q exec:java -Dexec.args="path/to/radar/images --output embeddings.bin --device cpu"
+```
+
+The command saves:
+- `embeddings.bin`: float32 little-endian embedding vectors (one row per image)
+- `embeddings.bin.json`: file list aligned with the embeddings
+
+## Notes
+
+- Supported extensions: PNG, JPEG, TIFF.
+- To use a GPU, pass `--device cuda` and ensure CUDA-enabled DJL PyTorch artifacts are
+  available on your system.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.obrienlabs</groupId>
+    <artifactId>radar-embeddings</artifactId>
+    <version>0.1.0</version>
+    <name>Radar Embeddings</name>
+    <description>Convert Doppler radar images into embeddings for generative models</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <djl.version>0.27.0</djl.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ai.djl</groupId>
+            <artifactId>api</artifactId>
+            <version>${djl.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.djl.pytorch</groupId>
+            <artifactId>pytorch-engine</artifactId>
+            <version>${djl.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.djl.pytorch</groupId>
+            <artifactId>pytorch-native-auto</artifactId>
+            <version>2.2.2</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <mainClass>dev.obrienlabs.radar.cli.RadarEmbed</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/dev/obrienlabs/radar/cli/RadarEmbed.java
+++ b/src/main/java/dev/obrienlabs/radar/cli/RadarEmbed.java
@@ -1,0 +1,53 @@
+package dev.obrienlabs.radar.cli;
+
+import ai.djl.ModelException;
+import ai.djl.translate.TranslateException;
+import dev.obrienlabs.radar.embedding.EmbeddingPipeline;
+import dev.obrienlabs.radar.embedding.EmbeddingResult;
+import java.io.IOException;
+import java.nio.file.Path;
+
+public final class RadarEmbed {
+    public static void main(String[] args) {
+        try {
+            Options options = Options.parse(args);
+            EmbeddingPipeline pipeline = new EmbeddingPipeline();
+            EmbeddingResult result = pipeline.embed(options.input(), options.device());
+            pipeline.save(result, options.output());
+            System.out.printf("Saved %d embeddings to %s%n", result.size(), options.output());
+        } catch (IllegalArgumentException | IOException | ModelException | TranslateException error) {
+            System.err.println("Error: " + error.getMessage());
+            System.exit(1);
+        }
+    }
+
+    private record Options(Path input, Path output, String device) {
+        static Options parse(String[] args) {
+            if (args.length == 0) {
+                printUsageAndExit();
+            }
+            Path input = Path.of(args[0]);
+            Path output = Path.of("embeddings.bin");
+            String device = "cpu";
+            for (int i = 1; i < args.length; i++) {
+                String arg = args[i];
+                if ("--output".equals(arg) && i + 1 < args.length) {
+                    output = Path.of(args[++i]);
+                } else if ("--device".equals(arg) && i + 1 < args.length) {
+                    device = args[++i];
+                } else if ("--help".equals(arg) || "-h".equals(arg)) {
+                    printUsageAndExit();
+                } else {
+                    throw new IllegalArgumentException("Unknown argument: " + arg);
+                }
+            }
+            return new Options(input, output, device);
+        }
+
+        private static void printUsageAndExit() {
+            System.out.println("Usage: radar-embed <input> [--output embeddings.bin] [--device cpu]");
+            System.out.println("  input: path to image or directory of images");
+            System.exit(0);
+        }
+    }
+}

--- a/src/main/java/dev/obrienlabs/radar/embedding/EmbeddingPipeline.java
+++ b/src/main/java/dev/obrienlabs/radar/embedding/EmbeddingPipeline.java
@@ -1,0 +1,136 @@
+package dev.obrienlabs.radar.embedding;
+
+import ai.djl.Application;
+import ai.djl.ModelException;
+import ai.djl.inference.Predictor;
+import ai.djl.modality.cv.Image;
+import ai.djl.modality.cv.ImageFactory;
+import ai.djl.modality.cv.transform.CenterCrop;
+import ai.djl.modality.cv.transform.Normalize;
+import ai.djl.modality.cv.transform.Pipeline;
+import ai.djl.modality.cv.transform.Resize;
+import ai.djl.modality.cv.transform.ToTensor;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ModelZoo;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.translate.TranslateException;
+import ai.djl.translate.Translator;
+import ai.djl.translate.TranslatorContext;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class EmbeddingPipeline {
+    private static final Set<String> SUPPORTED_EXTENSIONS =
+            Set.of(".png", ".jpg", ".jpeg", ".tif", ".tiff");
+
+    public List<Path> loadImagePaths(Path input) throws IOException {
+        if (Files.notExists(input)) {
+            throw new IllegalArgumentException("Input path not found: " + input);
+        }
+        if (Files.isRegularFile(input)) {
+            return List.of(input);
+        }
+        try (Stream<Path> stream = Files.walk(input)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .filter(path -> SUPPORTED_EXTENSIONS.contains(extensionOf(path)))
+                    .sorted(Comparator.naturalOrder())
+                    .collect(Collectors.toList());
+        }
+    }
+
+    public EmbeddingResult embed(Path input, String device) throws IOException, ModelException, TranslateException {
+        List<Path> imagePaths = loadImagePaths(input);
+        if (imagePaths.isEmpty()) {
+            throw new IllegalArgumentException("No images found to embed.");
+        }
+
+        Criteria<Image, float[]> criteria = Criteria.builder()
+                .optApplication(Application.CV.IMAGE_CLASSIFICATION)
+                .setTypes(Image.class, float[].class)
+                .optFilter("layers", "50")
+                .optTranslator(new LogitsTranslator())
+                .optDevice(ai.djl.Device.fromName(device))
+                .build();
+
+        List<float[]> embeddings = new ArrayList<>();
+        List<String> paths = new ArrayList<>();
+
+        try (ZooModel<Image, float[]> model = ModelZoo.loadModel(criteria);
+             Predictor<Image, float[]> predictor = model.newPredictor()) {
+            ImageFactory factory = ImageFactory.getInstance();
+            for (Path path : imagePaths) {
+                Image image = factory.fromFile(path);
+                float[] vector = predictor.predict(image);
+                embeddings.add(vector);
+                paths.add(path.toString());
+            }
+        }
+
+        float[][] array = embeddings.toArray(new float[0][]);
+        return new EmbeddingResult(array, paths);
+    }
+
+    public void save(EmbeddingResult result, Path output) throws IOException {
+        if (output.getParent() != null) {
+            Files.createDirectories(output.getParent());
+        }
+        EmbeddingWriter.writeBinary(output, result.embeddings());
+        int columns = result.embeddings().length == 0 ? 0 : result.embeddings()[0].length;
+        EmbeddingWriter.writeMetadata(output, columns, result.paths());
+    }
+
+    private static String extensionOf(Path path) {
+        String name = path.getFileName().toString().toLowerCase(Locale.ROOT);
+        int index = name.lastIndexOf('.');
+        if (index < 0) {
+            return "";
+        }
+        return name.substring(index);
+    }
+
+    private static final class LogitsTranslator implements Translator<Image, float[]> {
+        private final Pipeline pipeline;
+
+        private LogitsTranslator() {
+            pipeline = new Pipeline()
+                    .add(new Resize(256))
+                    .add(new CenterCrop(224, 224))
+                    .add(new ToTensor())
+                    .add(new Normalize(
+                            new float[]{0.485f, 0.456f, 0.406f},
+                            new float[]{0.229f, 0.224f, 0.225f}
+                    ));
+        }
+
+        @Override
+        public NDList processInput(TranslatorContext ctx, Image input) {
+            NDArray array = input.toNDArray(ctx.getNDManager());
+            array = pipeline.transform(array);
+            array = array.expandDims(0);
+            return new NDList(array);
+        }
+
+        @Override
+        public float[] processOutput(TranslatorContext ctx, NDList list) {
+            NDArray output = list.singletonOrThrow();
+            NDArray squeezed = output.squeeze(0);
+            return squeezed.toFloatArray();
+        }
+
+        @Override
+        public void close() {
+            // No resources to clean up.
+        }
+    }
+}

--- a/src/main/java/dev/obrienlabs/radar/embedding/EmbeddingResult.java
+++ b/src/main/java/dev/obrienlabs/radar/embedding/EmbeddingResult.java
@@ -1,0 +1,9 @@
+package dev.obrienlabs.radar.embedding;
+
+import java.util.List;
+
+public record EmbeddingResult(float[][] embeddings, List<String> paths) {
+    public int size() {
+        return embeddings == null ? 0 : embeddings.length;
+    }
+}

--- a/src/main/java/dev/obrienlabs/radar/embedding/EmbeddingWriter.java
+++ b/src/main/java/dev/obrienlabs/radar/embedding/EmbeddingWriter.java
@@ -1,0 +1,53 @@
+package dev.obrienlabs.radar.embedding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public final class EmbeddingWriter {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private EmbeddingWriter() {
+    }
+
+    public static void writeBinary(Path output, float[][] embeddings) throws IOException {
+        try (BufferedOutputStream stream = new BufferedOutputStream(Files.newOutputStream(output))) {
+            int columns = embeddings.length == 0 ? 0 : embeddings[0].length;
+            ByteBuffer buffer = ByteBuffer.allocate(4 * columns);
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+            for (float[] vector : embeddings) {
+                buffer.clear();
+                for (float value : vector) {
+                    buffer.putFloat(value);
+                }
+                stream.write(buffer.array());
+            }
+        }
+    }
+
+    public static void writeMetadata(Path output, int columns, List<String> paths) throws IOException {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("embedding_format", "float32_le");
+        root.put("output", output.getFileName().toString());
+        root.put("rows", paths.size());
+        root.put("columns", columns);
+        ArrayNode array = root.putArray("paths");
+        for (String path : paths) {
+            array.add(path);
+        }
+        Path metadata = metadataPath(output);
+        MAPPER.writerWithDefaultPrettyPrinter().writeValue(metadata.toFile(), root);
+    }
+
+    private static Path metadataPath(Path output) {
+        String name = output.getFileName().toString();
+        return output.resolveSibling(name + ".json");
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace the previous `com.obrienlabs` namespace with `dev.obrienlabs` to match domain ownership.
- Ensure Maven coordinates and the configured main class reflect the new organization group.
- Move Java sources into the matching package path so package names and filesystem layout are consistent.
- Preserve the existing embedding pipeline and CLI behavior while standardizing the package namespace.

### Description
- Update `pom.xml` to use `<groupId>dev.obrienlabs</groupId>` and set the `exec-maven-plugin` `mainClass` to `dev.obrienlabs.radar.cli.RadarEmbed`.
- Move Java sources from `src/main/java/com/obrienlabs/...` to `src/main/java/dev/obrienlabs/...` and remove the old paths.
- Adjust package declarations and imports in `RadarEmbed.java`, `EmbeddingPipeline.java`, `EmbeddingResult.java`, and `EmbeddingWriter.java` to `dev.obrienlabs.radar.*`.
- Commit the namespace changes and update the repository layout so the build now aligns with the new groupId.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955bd424714832e8ea4ddd59fea7368)