### PR TITLE
Initialize radar image embedding pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # doppler-radar-llm-codex
-doppler radar images model using codex - not the same as my manually created project at https://github.com/ObrienlabsDev/doppler-radar-ml
+
+Starter project for converting downloaded Doppler radar images into embeddings that can be
+fed into a generative model pipeline.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Embed radar imagery
+
+```bash
+radar-embed path/to/radar/images --output embeddings.npy --batch-size 32 --device cpu
+```
+
+The command saves:
+- `embeddings.npy`: `(N, 2048)` float array of ResNet-50 image embeddings
+- `embeddings.json`: file list aligned with the embeddings
+
+## Notes
+
+- Supported extensions: PNG, JPEG, TIFF.
+- To use a GPU, pass `--device cuda` and ensure CUDA-enabled PyTorch is installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "radar-embeddings"
+version = "0.1.0"
+description = "Convert Doppler radar images into embeddings for generative models"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}
+authors = [{name = "ObrienlabsDev"}]
+
+dependencies = [
+  "numpy>=1.24",
+  "pillow>=10.0",
+  "torch>=2.2",
+  "torchvision>=0.17",
+  "tqdm>=4.66",
+]
+
+[project.scripts]
+radar-embed = "radar_embeddings.cli:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/radar_embeddings/__init__.py
+++ b/src/radar_embeddings/__init__.py
@@ -1,0 +1,5 @@
+"""Radar image embedding utilities."""
+
+from radar_embeddings.embedding import embed_image_paths, load_image_paths
+
+__all__ = ["embed_image_paths", "load_image_paths"]

--- a/src/radar_embeddings/cli.py
+++ b/src/radar_embeddings/cli.py
@@ -1,0 +1,52 @@
+"""Command-line entry points for embedding radar images."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from radar_embeddings.embedding import embed_image_paths, load_image_paths, save_embeddings
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Convert Doppler radar images into embeddings for generative models."
+    )
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="Path to a radar image or directory of images.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("embeddings.npy"),
+        help="Output .npy file path for embeddings (metadata saved as .json).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=16,
+        help="Number of images per batch.",
+    )
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        help="Device to run inference on (cpu or cuda).",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    image_paths = load_image_paths(args.input)
+    result = embed_image_paths(image_paths, batch_size=args.batch_size, device=args.device)
+    save_embeddings(result, args.output)
+
+    print(f"Saved {len(result.paths)} embeddings to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/radar_embeddings/embedding.py
+++ b/src/radar_embeddings/embedding.py
@@ -1,0 +1,88 @@
+"""Embedding pipeline for radar imagery."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import numpy as np
+import torch
+from PIL import Image
+from torch import nn
+from torchvision import models, transforms
+from tqdm import tqdm
+
+SUPPORTED_EXTENSIONS = {".png", ".jpg", ".jpeg", ".tif", ".tiff"}
+
+
+@dataclass(frozen=True)
+class EmbeddingResult:
+    embeddings: np.ndarray
+    paths: List[str]
+
+
+def load_image_paths(root: Path) -> List[Path]:
+    if not root.exists():
+        raise FileNotFoundError(f"Input path not found: {root}")
+    if root.is_file():
+        return [root]
+    paths = [path for path in root.rglob("*") if path.suffix.lower() in SUPPORTED_EXTENSIONS]
+    return sorted(paths)
+
+
+def build_model(device: torch.device) -> nn.Module:
+    weights = models.ResNet50_Weights.DEFAULT
+    model = models.resnet50(weights=weights)
+    model.fc = nn.Identity()
+    model.eval()
+    return model.to(device)
+
+
+def build_preprocess() -> transforms.Compose:
+    weights = models.ResNet50_Weights.DEFAULT
+    return weights.transforms()
+
+
+def _batched(iterable: Sequence[Path], batch_size: int) -> Iterable[List[Path]]:
+    for index in range(0, len(iterable), batch_size):
+        yield list(iterable[index : index + batch_size])
+
+
+def embed_image_paths(
+    image_paths: Sequence[Path],
+    batch_size: int = 16,
+    device: str | torch.device = "cpu",
+) -> EmbeddingResult:
+    if not image_paths:
+        raise ValueError("No images found to embed.")
+
+    device = torch.device(device)
+    model = build_model(device)
+    preprocess = build_preprocess()
+
+    embeddings: List[np.ndarray] = []
+    recorded_paths: List[str] = []
+
+    with torch.no_grad():
+        for batch in tqdm(_batched(list(image_paths), batch_size), desc="Embedding"):
+            images = []
+            for path in batch:
+                image = Image.open(path).convert("RGB")
+                images.append(preprocess(image))
+                recorded_paths.append(str(path))
+
+            tensor = torch.stack(images).to(device)
+            outputs = model(tensor)
+            embeddings.append(outputs.cpu().numpy())
+
+    return EmbeddingResult(embeddings=np.concatenate(embeddings, axis=0), paths=recorded_paths)
+
+
+def save_embeddings(result: EmbeddingResult, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(output_path, result.embeddings)
+    metadata_path = output_path.with_suffix(".json")
+    with metadata_path.open("w", encoding="utf-8") as handle:
+        json.dump({"paths": result.paths}, handle, indent=2)


### PR DESCRIPTION
### Motivation
- Convert downloaded Doppler radar images into embeddings that can be consumed by generative model pipelines.
- Provide a simple, reusable CLI and library to batch, preprocess, and embed radar imagery.
- Leverage a pretrained ResNet-50 backbone to produce 2048-dimensional image vectors for downstream use.

### Description
- Add `pyproject.toml` with package metadata, runtime dependencies, and a `radar-embed` entry point.
- Implement `src/radar_embeddings/embedding.py` with `load_image_paths`, `embed_image_paths`, and `save_embeddings` using `ResNet50_Weights` preprocessing and a ResNet-50 trunk returning 2048-dim vectors.
- Add CLI `src/radar_embeddings/cli.py` exposing `radar-embed` with `--output`, `--batch-size`, and `--device` options to run the pipeline from the command line.
- Update `README.md` with setup and usage instructions and document outputs `embeddings.npy` and `embeddings.json` and supported extensions.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955bd424714832e8ea4ddd59fea7368)